### PR TITLE
Turn inmanta-dashboard into a scoped package

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "inmanta-dashboard",
+  "name": "@inmanta/inmanta-dashboard",
   "private": true,
   "version": "0.0.0",
   "description": "Inmanta Dashboard",


### PR DESCRIPTION
This is required, since GitHub Packages only supports scoped packages. 