### PR TITLE
added more fields to the compiler view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
 # Release 3.5.0 (?)
 
 - Specify environment id for the web console link (#96)
+- Add additional fields to Compile Report

--- a/app/views/compileReport/compileBody.html
+++ b/app/views/compileReport/compileBody.html
@@ -8,13 +8,23 @@
     </div>
 </div>
 <div class="row">
-    <div class="col-md-12 detail">
+    <div class="col-md-4 detail">
         <p><strong>Started:</strong> {{compile.started|date:'dd/MM/yyyy HH:mm'}}</p>
         <p><strong>Ended:</strong> {{compile.completed|date:'dd/MM/yyyy HH:mm'}}</p>
         <p><strong>Time (s):</strong> {{(compile.completed-compile.started)/1000}}</p>
     </div>
+    <div class="col-md-4 detail">
+        <p><strong>Export:</strong> {{compile.do_export}}</p>
+        <p><strong>Update:</strong> {{compile.force_update}}</p>
+        <p><strong>Type:</strong> {{compile.metadata.type}}</p>
+    </div>
 </div>
-
+<div class="row">
+    <div class="col-md-12 detail">
+        <p><strong>Message:</strong> {{compile.metadata.message}}</p>
+        <p><strong>User Error:</strong> {{compile.compile_data.errors[0].message}} </p>
+    </div>
+</div>
 <div class="row">
     <div class="col-md-12">
         <table class="table table-lined">

--- a/app/views/compileReport/compileBody.html
+++ b/app/views/compileReport/compileBody.html
@@ -22,7 +22,7 @@
 <div class="row">
     <div class="col-md-12 detail">
         <p><strong>Message:</strong> {{compile.metadata.message}}</p>
-        <p><strong>User Error:</strong> {{compile.compile_data.errors[0].message}} </p>
+        <p><strong>User Error:</strong> <span ng-if="compile.compile_data.errors.length>0">{{compile.compile_data.errors[0].message}}</span> </p>
     </div>
 </div>
 <div class="row">


### PR DESCRIPTION
# Description

Added more information to compiler view:

Added fields type, export, message and error.

![image](https://user-images.githubusercontent.com/1788254/91814030-cf157a80-ec33-11ea-8eb2-c65cf88fc858.png)


# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Code is clear and sufficiently documented
- [ ] ~~Sufficient test cases (reproduces the bug/tests the requested feature)~~
- [x] Correct, in line with design
- [] ~~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
